### PR TITLE
Update qt_nl.ts

### DIFF
--- a/qt_nl.ts
+++ b/qt_nl.ts
@@ -211,7 +211,7 @@
     </message>
     <message>
         <source>Print</source>
-        <translation>Afdrukken</translation>
+        <translation>Print Screen</translation>
     </message>
     <message>
         <source>Right</source>
@@ -231,7 +231,7 @@
     </message>
     <message>
         <source>Print Screen</source>
-        <translation>Schermafdruk</translation>
+        <translation>Print Screen</translation>
     </message>
     <message>
         <source>Treble Down</source>

--- a/qt_nl.ts
+++ b/qt_nl.ts
@@ -211,7 +211,7 @@
     </message>
     <message>
         <source>Print</source>
-        <translation>Print Screen</translation>
+        <translation>Print</translation>
     </message>
     <message>
         <source>Right</source>


### PR DESCRIPTION
Fixing 2 problems.
1. <source>Print</source> apparently is connected to the Print Screen keyboard button. Translation is now "Print Screen"
2. I don't know what <source>Print Screen</source> is for, but I expect this to be the Print Screen button, so I gave it the same non-translation.

Issue #1 is strange. Is it an error in QT or an error in Snipaste's use of QT?