### PR TITLE
Update nl_nl.ts

### DIFF
--- a/nl_nl.ts
+++ b/nl_nl.ts
@@ -2911,7 +2911,7 @@ Dit zorgt voor een snellere opstart van Knippen.</translation>
     </message>
     <message>
         <source>Keys</source>
-        <translation>Sleutels</translation>
+        <translation>Toetsen</translation>
     </message>
     <message>
         <source>Actions</source>


### PR DESCRIPTION
Fixed incorrect translation. Keys = keyboard keys (toetsen) and not unlocking keys (sleutels)